### PR TITLE
Current Value Subjects

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -11,7 +11,7 @@ jobs:
   SwiftActions:
     strategy:
       matrix:
-        os: [macos-14, ubuntu-latest]
+        os: [macos-14, ubuntu-latest, macos-12]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -11,7 +11,7 @@ jobs:
   SwiftActions:
     strategy:
       matrix:
-        os: [macos-14, ubuntu-latest, macos-12]
+        os: [macos-latest, ubuntu-latest]
 
     runs-on: ${{ matrix.os }}
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ Wrappers around `Async[Throwing]Stream` that maintain continuation/termination l
 
 Swift actor that maintains references to multiple passthrough sequences. This allows for a _shared_ publisher similar to **Combine** `PassthroughSubject`.
 
+**Current Value Subjects**
+
+* [`CurrentValueAsyncSubject`](Sources/AsyncPlus/CurrentValueAsyncSubject.swift)
+* [`CurrentValueAsyncThrowingSubject`](Sources/AsyncPlus/CurrentValueAsyncThrowingSubject.swift)
+
+Swift actor that maintains references to multiple streams. This allows for a _shared_ publisher similar to **Combine** `CurrentValueSubject`.
+
 ## Alternatives
 
 * [Swift Async-Algorithms](https://github.com/apple/swift-async-algorithms)

--- a/Sources/AsyncPlus/CurrentValueAsyncSubject.swift
+++ b/Sources/AsyncPlus/CurrentValueAsyncSubject.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+public final actor CurrentValueAsyncSubject<Output> {
+    
+    public private(set) var value: Output
+    
+    private var subscriptions: [UUID: AsyncStream<Output>.Continuation] = [:]
+    
+    public init(_ value: Output) {
+        self.value = value
+    }
+    
+    public func sink() -> AsyncStream<Output> {
+        let id = UUID()
+        let sequence = AsyncStream.makeStream(of: Output.self)
+        sequence.continuation.onTermination = { [weak self] _ in
+            guard let self else {
+                return
+            }
+            
+            Task {
+                await self.terminate(id)
+            }
+        }
+        
+        subscriptions[id] = sequence.continuation
+        
+        defer {
+            sequence.continuation.yield(value)
+        }
+        
+        return sequence.stream
+    }
+    
+    public func yield(_ value: Output) {
+        self.value = value
+        
+        guard !subscriptions.isEmpty else {
+            return
+        }
+        
+        for (_, sequence) in subscriptions {
+            sequence.yield(value)
+        }
+    }
+    
+    public func finish() {
+        guard !subscriptions.isEmpty else {
+            return
+        }
+        
+        for (_, sequence) in subscriptions {
+            sequence.finish()
+        }
+        
+        subscriptions.removeAll()
+    }
+    
+    internal func subscriberCount() -> Int {
+        subscriptions.count
+    }
+    
+    private func terminate(_ id: UUID) {
+        subscriptions[id] = nil
+    }
+}

--- a/Sources/AsyncPlus/CurrentValueAsyncThrowingSubject.swift
+++ b/Sources/AsyncPlus/CurrentValueAsyncThrowingSubject.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+public final actor CurrentValueAsyncThrowingSubject<Output, Failure> where Failure: Error {
+    
+    public private(set) var value: Output
+    
+    private var subscriptions: [UUID: AsyncThrowingStream<Output, Failure>.Continuation] = [:]
+    
+    public init(_ value: Output, throwing: Failure.Type) where Failure == any Error {
+        self.value = value
+    }
+    
+    public func sink() -> AsyncThrowingStream<Output, Failure> where Failure == any Error {
+        let id = UUID()
+        let sequence = AsyncThrowingStream.makeStream(of: Output.self, throwing: Failure.self)
+        sequence.continuation.onTermination = { [weak self] _ in
+            guard let self else {
+                return
+            }
+            
+            Task {
+                await self.terminate(id)
+            }
+        }
+        subscriptions[id] = sequence.continuation
+        
+        defer {
+            sequence.continuation.yield(value)
+        }
+        
+        return sequence.stream
+    }
+    
+    public func yield(_ value: Output) {
+        self.value = value
+        
+        guard !subscriptions.isEmpty else {
+            return
+        }
+        
+        for (_, sequence) in subscriptions {
+            sequence.yield(value)
+        }
+    }
+    
+    public func finish(throwing error: Failure? = nil) {
+        guard !subscriptions.isEmpty else {
+            return
+        }
+        
+        for (_, sequence) in subscriptions {
+            sequence.finish(throwing: error)
+        }
+        
+        subscriptions.removeAll()
+    }
+    
+    internal func subscriberCount() -> Int {
+        subscriptions.count
+    }
+    
+    private func terminate(_ id: UUID) {
+        subscriptions[id] = nil
+    }
+}

--- a/Sources/AsyncPlus/PassthroughAsyncSubject.swift
+++ b/Sources/AsyncPlus/PassthroughAsyncSubject.swift
@@ -1,49 +1,60 @@
 import Foundation
 
+/// An actor which maintains and yeilds output to multiple `AsyncStream` subscriptions.
+///
+/// Unlike `CurrentValueAsyncSubject`, a `PassthroughAsyncSubject` doesn’t have an
+/// initial value or a buffer of the most recently-published element.
 public final actor PassthroughAsyncSubject<Output> {
     
-    private var subscriptions: [UUID: PassthroughAsyncSequence<Output>] = [:]
+    internal private(set) var subscriptions: [UUID: AsyncStream<Output>.Continuation] = [:]
     
     public init() {
     }
     
+    /// Vends a new `AsyncStream` that will recieve all future output.
+    ///
+    /// The stream will be _alive_ as long as the downstream reference is maintained
+    /// or the subject has not _finished_.
     public func sink() -> AsyncStream<Output> {
         let id = UUID()
-        let sequence = PassthroughAsyncSequence<Output> { _ in
+        let sequence = AsyncStream.makeStream(of: Output.self)
+        sequence.continuation.onTermination = { [weak self] _ in
+            guard let self else {
+                return
+            }
+            
             Task {
                 await self.terminate(id)
             }
         }
         
-        subscriptions[id] = sequence
+        subscriptions[id] = sequence.continuation
         
         return sequence.stream
     }
     
+    /// Resumes all subscriber tasks and sends the provided value.
     public func yield(_ value: Output) {
         guard !subscriptions.isEmpty else {
             return
         }
         
-        for (_, sequence) in subscriptions {
-            sequence.yield(value)
+        for (_, continuation) in subscriptions {
+            continuation.yield(value)
         }
     }
     
+    /// Resumes all subscriber tasks with a `nil` value indicating the termination of the stream.
     public func finish() {
         guard !subscriptions.isEmpty else {
             return
         }
         
-        for (_, sequence) in subscriptions {
-            sequence.finish()
+        for (_, continuation) in subscriptions {
+            continuation.finish()
         }
         
         subscriptions.removeAll()
-    }
-    
-    internal func subscriberCount() -> Int {
-        subscriptions.count
     }
     
     private func terminate(_ id: UUID) {

--- a/Sources/AsyncPlus/PassthroughAsyncThrowingSubject.swift
+++ b/Sources/AsyncPlus/PassthroughAsyncThrowingSubject.swift
@@ -1,25 +1,36 @@
 import Foundation
 
+/// An actor which maintains and yeilds output to multiple `AsyncThrowingStream` subscriptions.
 public final actor PassthroughAsyncThrowingSubject<Output> {
     
-    private var subscriptions: [UUID: PassthroughAsyncThrowingSequence<Output>] = [:]
+    internal private(set) var subscriptions: [UUID: AsyncThrowingStream<Output, Error>.Continuation] = [:]
     
     public init() {
     }
     
+    /// Vends a new `AsyncThrowingStream` that will recieve all future output/errors.
+    ///
+    /// The stream will be _alive_ as long as the downstream reference is maintained
+    /// or the subject has not _finished_.
     public func sink() -> AsyncThrowingStream<Output, Error> {
         let id = UUID()
-        let sequence = PassthroughAsyncThrowingSequence<Output> { _ in
+        let sequence = AsyncThrowingStream.makeStream(of: Output.self, throwing: Error.self)
+        sequence.continuation.onTermination = { [weak self] _ in
+            guard let self else {
+                return
+            }
+            
             Task {
                 await self.terminate(id)
             }
         }
         
-        subscriptions[id] = sequence
+        subscriptions[id] = sequence.continuation
         
         return sequence.stream
     }
     
+    /// Resumes all subscriber tasks and sends the provided value.
     public func yield(_ value: Output) {
         guard !subscriptions.isEmpty else {
             return
@@ -30,6 +41,8 @@ public final actor PassthroughAsyncThrowingSubject<Output> {
         }
     }
     
+    /// Resumes all subscriber tasks with a `nil` value or `Error`
+    /// indicating the termination of the stream.
     public func finish(throwing error: (any Error)? = nil) {
         guard !subscriptions.isEmpty else {
             return
@@ -40,10 +53,6 @@ public final actor PassthroughAsyncThrowingSubject<Output> {
         }
         
         subscriptions.removeAll()
-    }
-    
-    internal func subscriberCount() -> Int {
-        subscriptions.count
     }
     
     private func terminate(_ id: UUID) {

--- a/Tests/AsyncPlusTests/CurrentValueSubjectTests.swift
+++ b/Tests/AsyncPlusTests/CurrentValueSubjectTests.swift
@@ -1,0 +1,113 @@
+import XCTest
+@testable import AsyncPlus
+
+final class CurrentValueSubjectTests: XCTestCase {
+    
+    /// Verify that a _new_ subscriber receives the _current_ value from the subject.
+    ///
+    /// This also validates that canceling a subscription `Task` will also remove the subscriber.
+    func testSingleSubscriber() async throws {
+        let subject = CurrentValueAsyncSubject(0)
+        var value = await subject.value
+        XCTAssertEqual(value, 0)
+        
+        let subscription1 = Task {
+            var output: [Int] = []
+            
+            for await element in await subject.sink() {
+                output.append(element)
+            }
+            
+            return output
+        }
+        
+        try await Task.sleep(for: .seconds(0.1))
+        await subject.yield(1)
+        value = await subject.value
+        XCTAssertEqual(value, 1)
+        
+        var subscriberCount = await subject.subscriberCount()
+        XCTAssertEqual(subscriberCount, 1)
+        
+        subscription1.cancel()
+        try await Task.sleep(for: .seconds(0.1))
+        
+        subscriberCount = await subject.subscriberCount()
+        XCTAssertEqual(subscriberCount, 0)
+        
+        let values = await subscription1.value
+        XCTAssertEqual(values, [0, 1])
+    }
+    
+    /// Verify that a _new_ subscriber receives the _current_ and future values from the subject.
+    func testMultipleSubscribers() async throws {
+        let subject = CurrentValueAsyncSubject(0)
+        
+        let subscription1 = Task {
+            var output: [Int] = []
+            
+            for await element in await subject.sink() {
+                output.append(element)
+            }
+            
+            return output
+        }
+        
+        try await Task.sleep(for: .seconds(0.1))
+        await subject.yield(1)
+        
+        subscription1.cancel()
+        try await Task.sleep(for: .seconds(0.1))
+        
+        let subscription2 = Task {
+            var output: [Int] = []
+            
+            for await element in await subject.sink() {
+                output.append(element)
+            }
+            
+            return output
+        }
+        
+        try await Task.sleep(for: .seconds(0.1))
+        await subject.yield(2)
+        
+        subscription2.cancel()
+        try await Task.sleep(for: .seconds(0.1))
+        
+        let subscription1Values = await subscription1.value
+        let subscription2Values = await subscription2.value
+        
+        XCTAssertEqual(subscription1Values, [0, 1])
+        XCTAssertEqual(subscription2Values, [1, 2])
+    }
+    
+//    func testThrowingTerminatesSubscribers() async throws {
+//        struct ExpectedError: Error {}
+//        
+//        let subject = CurrentValueAsyncThrowingSubject(0, throwing: ExpectedError.self)
+//        
+//        let subscription1 = Task {
+//            var output: [Int] = []
+//            
+//            for await element in await subject.sink() {
+//                output.append(element)
+//            }
+//            
+//            return output
+//        }
+//        
+//        let subscription2 = Task {
+//            var output: [Int] = []
+//            
+//            for await element in await subject.sink() {
+//                output.append(element)
+//            }
+//            
+//            return output
+//        }
+//        
+//        try await Task.sleep(for: .seconds(0.1))
+//        await subject.yield(1)
+//    }
+}

--- a/Tests/AsyncPlusTests/PassthroughSequenceTests.swift
+++ b/Tests/AsyncPlusTests/PassthroughSequenceTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 @testable import AsyncPlus
 
-final class SequenceTests: XCTestCase {
+final class PassthroughSequenceTests: XCTestCase {
     
     func testAsyncSequence() async throws {
         let sequence = PassthroughAsyncSequence<Int>()

--- a/Tests/AsyncPlusTests/PassthroughSubjectTests.swift
+++ b/Tests/AsyncPlusTests/PassthroughSubjectTests.swift
@@ -21,7 +21,7 @@ final class PassthroughSubjectTests: XCTestCase {
         await subject.yield(2)
         await subject.yield(3)
         await subject.finish()
-        let subscriberCount = await subject.subscriberCount()
+        let subscriberCount = await subject.subscriptions.count
         
         let values = await task1.value
         XCTAssertEqual(values.count, 3)
@@ -59,7 +59,7 @@ final class PassthroughSubjectTests: XCTestCase {
         await subject.yield(2)
         await subject.yield(3)
         await subject.finish()
-        let subscriberCount = await subject.subscriberCount()
+        let subscriberCount = await subject.subscriptions.count
         
         let values1 = await task1.value
         XCTAssertEqual(values1.count, 3)
@@ -92,7 +92,7 @@ final class PassthroughSubjectTests: XCTestCase {
         task1.cancel()
         
         try await Task.sleep(nanoseconds: 500_000_000)
-        let subscriberCount = await subject.subscriberCount()
+        let subscriberCount = await subject.subscriptions.count
         XCTAssertEqual(subscriberCount, 0)
         
         await subject.yield(3)

--- a/Tests/AsyncPlusTests/PassthroughSubjectTests.swift
+++ b/Tests/AsyncPlusTests/PassthroughSubjectTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 @testable import AsyncPlus
 
-final class SubjectTests: XCTestCase {
+final class PassthroughSubjectTests: XCTestCase {
     
     func testSingleSubscriber() async throws {
         let subject = PassthroughAsyncSubject<Int>()


### PR DESCRIPTION
Adds 'Current Value' Subjects to mirror the Combine `CurrentValueSubject` but using swift concurrency.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] I have added tests for new functionality
- [ ] All the tests have passed

## ⁉️ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
